### PR TITLE
Check channel admin status before +o

### DIFF
--- a/src/watcher/listener.rs
+++ b/src/watcher/listener.rs
@@ -53,7 +53,7 @@ impl Listener for Watcher {
         }
 
         // +o bot admin
-        if self.is_admin(&user.nickname()) {
+        if self.admin_channel(channel.name()) && self.is_admin(&user.nickname()) {
             match irc.raw(format!("MODE {} +o {}", channel.name(), user.nickname())) {
                 Err(e) => println!("{:?}", e),
                 Ok(_) => println!("+o {}", user.nickname()),


### PR DESCRIPTION
User should only be made a channel admin if the bot is a channel admin. (Duh.)
