### PR TITLE
Use chrono in place of time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["J/A <archer884@gmail.com>"]
 
 [dependencies]
+chrono = "*"
 clippy = {version = "*", optional = true}
 dice = {git = "https://github.com/archer884/dice.git"}
 fortune-cookie = {git = "https://github.com/archer884/fortune-cookie.git", default-features = false}
@@ -14,7 +15,6 @@ regex = "*"
 rsilio = {git = "https://github.com/archer884/rsilio.git", default-features = false}
 serde = "*"
 serde_derive = "*"
-time = "*"
 toml = {version = "*", default-features = false, features = ["serde"]}
 
 [dependencies.hiirc]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate serde_derive;
 
+extern crate chrono;
 extern crate dice;
 extern crate fortune_cookie;
 extern crate hiirc;
@@ -14,7 +15,6 @@ extern crate rand;
 extern crate regex;
 extern crate rsilio;
 extern crate serde;
-extern crate time;
 extern crate toml;
 
 mod command;

--- a/src/watcher/listener.rs
+++ b/src/watcher/listener.rs
@@ -89,7 +89,8 @@ impl Listener for Watcher {
     }
 
     fn reconnect(&mut self, _: IrcHndl) {
-        // no idea what this needs to do here
+        use chrono::UTC;
+        println!("reconnect occurred: {}", UTC::now().format("%F %T"));
     }
 
     fn welcome(&mut self, irc: IrcHndl) {

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -120,14 +120,11 @@ impl Watcher {
     }
 
     fn open_log(&self, channel: &str) -> Result<File, IoError> {
-        use time;
+        use chrono::UTC;
 
         // I was going to write a test for this unwrap call, but, honestly, I figure everyone
         // and their dog knows that this particular format specifier is fine...
-        let path = format!("{}/{}",
-                           self.log_path,
-                           time::strftime("%F", &time::now()).unwrap() + "_" +
-                           channel.trim_left_matches('#') + ".log");
+        let path = format!("{}/{}_{}.log", self.log_path, UTC::now().format("%F"), channel.trim_left_matches('#'));
         OpenOptions::new().write(true).create(true).append(true).open(&path)
     }
 


### PR DESCRIPTION
I'm more familiar with `chrono` than with `time` at this point, and I think it's just generally the more robust of the two libraries. Of course, I understand we're really only using this in two places...
