### PR TITLE
Provide a command that lists commands

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 pub enum Command {
     Chuck,
     Cookie,
+    ListCommands,
     Quote(Option<String>),
     Roll(Vec<Dice>),
 
@@ -32,6 +33,7 @@ impl FromStr for Command {
             [".cookie"] => Ok(Command::Cookie),
             [".quote"] => Ok(Command::Quote(None)),
             [".quote", category] => Ok(Command::Quote(Some(category.into()))),
+            [".list"] => Ok(Command::ListCommands),
             [".roll", ref commands..] => Ok(Command::Roll(create_dice(commands))),
 
             // bot options

--- a/src/watcher/commands.rs
+++ b/src/watcher/commands.rs
@@ -27,6 +27,12 @@ pub fn cookie(sender: String) -> Option<OutgoingMessage> {
     )
 }
 
+pub fn list_commands() -> Option<OutgoingMessage> {
+    Some(OutgoingMessage::ChannelMessage {
+        content: String::from(".chuck .cookie .quote .quote <category> .roll <1d6>")
+    })
+}
+
 pub fn quote(sender: String, category: Option<String>) -> Option<OutgoingMessage> {
     use quote_rs::Service;
 

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -48,6 +48,7 @@ impl Watcher {
             Ok(command) => match command {
                 Command::Chuck => commands::chuck(sender),
                 Command::Cookie => commands::cookie(sender),
+                Command::ListCommands => commands::list_commands(),
                 Command::Quote(category) => commands::quote(sender, category),
                 Command::Roll(dice) => commands::roll(sender, dice),
 


### PR DESCRIPTION
This PR adds a command that permits the user to list some innocuous commands. The formatting is terrible and it gets printed straight into the channel, but it works and it kills the issue.

Closes #10 