### PR TITLE
Add command to list quote categories

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -6,6 +6,7 @@ pub enum Command {
     Cookie,
     ListCommands,
     Quote(Option<String>),
+    QuoteCategories,
     Roll(Vec<Dice>),
 
     // bot options

--- a/src/watcher/commands.rs
+++ b/src/watcher/commands.rs
@@ -51,6 +51,10 @@ pub fn quote(sender: String, category: Option<String>) -> Option<OutgoingMessage
     )
 }
 
+pub fn list_quote_categories() -> Option<OutgoingMessage> {
+    Some(OutgoingMessage::const_to_channel("inspire, management, sports, life, funny, love, art, students"))
+}
+
 pub fn roll(sender: String, dice: Vec<Dice>) -> Option<OutgoingMessage> {
     use rand;
 

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -50,6 +50,7 @@ impl Watcher {
                 Command::Cookie => commands::cookie(sender),
                 Command::ListCommands => commands::list_commands(),
                 Command::Quote(category) => commands::quote(sender, category),
+                Command::QuoteCategories => commands::list_quote_categories(),
                 Command::Roll(dice) => commands::roll(sender, dice),
 
                 // FIXME: Admin commands like these need a separate pathway.


### PR DESCRIPTION
This PR adds a command that lists the quote of the day categories for TheySaidSo. There is an API call for this, but we're not using it because they never change the categories. Additionally, this PR toys with the idea of adding a special class of static messages, but I think we should tackle that problem by making normal messages Cow<'static, str> instead.

Closes #9 